### PR TITLE
Add lexical binding cookie

### DIFF
--- a/hide-lines.el
+++ b/hide-lines.el
@@ -1,4 +1,4 @@
-;;; hide-lines.el --- Commands for hiding lines based on a regexp
+;;; hide-lines.el --- Commands for hiding lines based on a regexp  -*- lexical-binding: nil; -*-
 
 ;; Filename: hide-lines.el
 ;; Description: Commands for hiding lines based on a regexp


### PR DESCRIPTION
Emacs 31 now gives noisy warnings when loading a file that doesn't specify binding style.  For example:

  Warning (files): Missing ‘lexical-binding’ cookie in ".../hide-lines.el".
  You can add one with ‘M-x elisp-enable-lexical-binding RET’.
  See ‘(elisp)Selecting Lisp Dialect’ and ‘(elisp)Converting to Lexical Binding’
  for more information.

This change silences that warning.  More information can be found in the two above-referenced two Info nodes, which are online here:

https://www.gnu.org/software/emacs/manual/html_node/elisp/Selecting-Lisp-Dialect.html

https://www.gnu.org/software/emacs/manual/html_node/elisp/Converting-to-Lexical-Binding.html